### PR TITLE
fixed fileinput

### DIFF
--- a/djgentelella/widgets/core.py
+++ b/djgentelella/widgets/core.py
@@ -194,11 +194,12 @@ class FileInput(DJFileInput):
     def value_from_datadict(self, data, files, name):
         dev = None
         token = data.get(name)
-        load_token = json.loads(token)
-        tmpupload = ChunkedUpload.objects.filter(upload_id=load_token['token']).first()
-        if tmpupload:
-            dev = tmpupload.get_uploaded_file()
-            tmpupload.delete()
+        if token:
+            load_token = json.loads(token)
+            tmpupload = ChunkedUpload.objects.filter(upload_id=load_token['token']).first()
+            if tmpupload:
+                dev = tmpupload.get_uploaded_file()
+                tmpupload.delete()
         return dev
 
     def value_omitted_from_data(self, data, files, name):


### PR DESCRIPTION
Added a check for the presence of a token before attempting to load and process it in the value_from_datadict method. This prevents errors when the token is missing from the submitted data.
Changes:
Wrapped the token handling logic in an if token condition.
This ensures that json.loads() and related database queries are only executed when a token is actually provided.
Reason:
Previously, if token was not present in the request data, the method would attempt to parse None, resulting in a TypeError. 