### PR TITLE
Fixed 0.6.1

### DIFF
--- a/demo/demo/views.py
+++ b/demo/demo/views.py
@@ -107,7 +107,8 @@ class ExampleForm(GTForm):
     your_radio = forms.ChoiceField(choices=(
         ('enero', 'Enero'),
         ('febrero', 'Febrero'),
-        ('marzo,abril', 'Marzo,Abril')
+        ('marzo', 'Marzo'),
+        ('abril', 'Abril')
     ), widget=genwidgets.RadioHorizontalSelect)
     your_radio_vertical = forms.ChoiceField(choices=(
         ('enero', 'Enero'), ('febrero', 'Febrero'),

--- a/demo/demo/views.py
+++ b/demo/demo/views.py
@@ -107,8 +107,7 @@ class ExampleForm(GTForm):
     your_radio = forms.ChoiceField(choices=(
         ('enero', 'Enero'),
         ('febrero', 'Febrero'),
-        ('marzo', 'Marzo'),
-        ('abril', 'Abril')
+        ('marzo,abril', 'Marzo,Abril')
     ), widget=genwidgets.RadioHorizontalSelect)
     your_radio_vertical = forms.ChoiceField(choices=(
         ('enero', 'Enero'), ('febrero', 'Febrero'),

--- a/demo/demoapp/cardlist/forms.py
+++ b/demo/demoapp/cardlist/forms.py
@@ -25,14 +25,6 @@ class CardListPerson(GTForm, forms.ModelForm):
 
 
 class CardListPersonForm(GTForm, forms.ModelForm):
-    """Add/edit form for the create and update modals of the card list demo.
-
-    A separate form from ``CardListPerson``: that one is the filter bar, which
-    only exposes the three fields worth filtering by. Creating or editing a
-    Person needs every required model field, ``born_date`` and ``last_time``
-    included, or the API rejects the submission as incomplete.
-    """
-
     class Meta:
         model = Person
         fields = ['name', 'num_children', 'country', 'born_date', 'last_time']

--- a/demo/demoapp/cardlist/forms.py
+++ b/demo/demoapp/cardlist/forms.py
@@ -22,3 +22,24 @@ class CardListPerson(GTForm, forms.ModelForm):
             'num_children': genwidgets.NumberInput,
             'country': AutocompleteSelect('countrybasename')
         }
+
+
+class CardListPersonForm(GTForm, forms.ModelForm):
+    """Add/edit form for the create and update modals of the card list demo.
+
+    A separate form from ``CardListPerson``: that one is the filter bar, which
+    only exposes the three fields worth filtering by. Creating or editing a
+    Person needs every required model field, ``born_date`` and ``last_time``
+    included, or the API rejects the submission as incomplete.
+    """
+
+    class Meta:
+        model = Person
+        fields = ['name', 'num_children', 'country', 'born_date', 'last_time']
+        widgets = {
+            'name': genwidgets.TextInput,
+            'num_children': genwidgets.NumberInput,
+            'country': AutocompleteSelect('countrybasename'),
+            'born_date': genwidgets.DateInput,
+            'last_time': genwidgets.DateTimeInput,
+        }

--- a/demo/demoapp/cardlist/serializer.py
+++ b/demo/demoapp/cardlist/serializer.py
@@ -32,12 +32,20 @@ class PersonCardSerializer(serializers.ModelSerializer):
     actions = serializers.SerializerMethodField()
 
     def get_actions(self, obj):
-        return [{
-            'id': obj.pk,
-            'name': 'example',
-            'icon': 'fa fa-edit',
-            'title': 'example of action'
-        }]
+        return [
+            {
+                'id': obj.pk,
+                'name': 'edit',
+                'icon': 'fa fa-edit',
+                'title': _('Edit'),
+            },
+            {
+                'id': obj.pk,
+                'name': 'delete',
+                'icon': 'fa fa-trash',
+                'title': _('Delete'),
+            },
+        ]
 
     class Meta:
         model = Person
@@ -71,17 +79,35 @@ class PersonCreateSerializer(serializers.ModelSerializer):
         fields = '__all__'
 
 
-class CountrySerializer(serializers.ModelSerializer):
+class PersonUpdateSerializer(serializers.ModelSerializer):
+    """Write side of the edit modal: PUT/PATCH.
+
+    ``country`` is left to the default DRF behaviour -- a plain writable
+    ``PrimaryKeyRelatedField`` -- on purpose. A nested ``CountrySerializer()``
+    here would make it read-only for writes (DRF does not resolve nested
+    objects back into a related instance without a custom ``update()``), and
+    the whole point of this serializer is accepting the id the edit form
+    submits.
+    """
+    born_date = GTDateField()
+    last_time = GTDateTimeField()
+
     class Meta:
-        model = Country
+        model = Person
         fields = '__all__'
 
 
-class PersonUpdateSerializer(serializers.ModelSerializer):
+class PersonCardUpdateValuesSerializer(serializers.ModelSerializer):
+    """Read side of the edit modal: what pre-fills the form when it opens.
+
+    Unlike ``PersonUpdateSerializer``, ``country`` is nested here -- the edit
+    form's select2 box needs the country's name to display, not just its id.
+    Never used to accept a write, so the nested field being read-only is fine.
+    """
     born_date = GTDateField()
     last_time = GTDateTimeField()
     country = CountrySerializer()
 
     class Meta:
         model = Person
-        fields = '__all__'
+        fields = ['id', 'name', 'num_children', 'country', 'born_date', 'last_time']

--- a/demo/demoapp/cardlist/serializer.py
+++ b/demo/demoapp/cardlist/serializer.py
@@ -80,15 +80,6 @@ class PersonCreateSerializer(serializers.ModelSerializer):
 
 
 class PersonUpdateSerializer(serializers.ModelSerializer):
-    """Write side of the edit modal: PUT/PATCH.
-
-    ``country`` is left to the default DRF behaviour -- a plain writable
-    ``PrimaryKeyRelatedField`` -- on purpose. A nested ``CountrySerializer()``
-    here would make it read-only for writes (DRF does not resolve nested
-    objects back into a related instance without a custom ``update()``), and
-    the whole point of this serializer is accepting the id the edit form
-    submits.
-    """
     born_date = GTDateField()
     last_time = GTDateTimeField()
 
@@ -98,12 +89,6 @@ class PersonUpdateSerializer(serializers.ModelSerializer):
 
 
 class PersonCardUpdateValuesSerializer(serializers.ModelSerializer):
-    """Read side of the edit modal: what pre-fills the form when it opens.
-
-    Unlike ``PersonUpdateSerializer``, ``country`` is nested here -- the edit
-    form's select2 box needs the country's name to display, not just its id.
-    Never used to accept a write, so the nested field being read-only is fine.
-    """
     born_date = GTDateField()
     last_time = GTDateTimeField()
     country = CountrySerializer()

--- a/demo/demoapp/cardlist/views.py
+++ b/demo/demoapp/cardlist/views.py
@@ -1,6 +1,12 @@
 from django.shortcuts import render
 
+from .forms import CardListPersonForm
+
 
 # CardTable
 def cardListViewExample(response):
-    return render(response, 'gentelella/cardlist/cardList.html')
+    context = {
+        'create_form': CardListPersonForm(prefix='create'),
+        'update_form': CardListPersonForm(prefix='update'),
+    }
+    return render(response, 'gentelella/cardlist/cardList.html', context)

--- a/demo/demoapp/cardlist/viewsets.py
+++ b/demo/demoapp/cardlist/viewsets.py
@@ -35,9 +35,6 @@ class PersonCardListViewSet(mixins.CreateModelMixin, mixins.RetrieveModelMixin,
     def get_serializer_class(self):
         if self.action == 'create':
             return PersonCreateSerializer
-        # 'retrieve' feeds the edit modal when it opens: it needs the
-        # country's name, not just its id, so it gets the nested-for-display
-        # serializer instead of the flat one 'update'/'partial_update' write.
         if self.action == 'retrieve':
             return PersonCardUpdateValuesSerializer
         if self.action in ('update', 'partial_update'):

--- a/demo/demoapp/cardlist/viewsets.py
+++ b/demo/demoapp/cardlist/viewsets.py
@@ -1,11 +1,21 @@
+from django.utils.translation import gettext_lazy as _
+from rest_framework import mixins
+
 from djgentelella.views.listAreaViewset import ListAreaViewset
 from .filterset import PersonCardListFilterSet
 from .forms import CardListPerson
-from .serializer import PersonCardSerializer
+from .serializer import (
+    PersonCardSerializer,
+    PersonCardUpdateValuesSerializer,
+    PersonCreateSerializer,
+    PersonUpdateSerializer,
+)
 from ..models import Person
 
 
-class PersonCardListViewSet(ListAreaViewset):
+class PersonCardListViewSet(mixins.CreateModelMixin, mixins.RetrieveModelMixin,
+                            mixins.UpdateModelMixin, mixins.DestroyModelMixin,
+                            ListAreaViewset):
     serializer_class = PersonCardSerializer
     queryset = Person.objects.all()
     search_fields = ['name', 'num_children']
@@ -22,10 +32,22 @@ class PersonCardListViewSet(ListAreaViewset):
         queryset = super().filter_queryset(queryset)
         return queryset
 
+    def get_serializer_class(self):
+        if self.action == 'create':
+            return PersonCreateSerializer
+        # 'retrieve' feeds the edit modal when it opens: it needs the
+        # country's name, not just its id, so it gets the nested-for-display
+        # serializer instead of the flat one 'update'/'partial_update' write.
+        if self.action == 'retrieve':
+            return PersonCardUpdateValuesSerializer
+        if self.action in ('update', 'partial_update'):
+            return PersonUpdateSerializer
+        return super().get_serializer_class()
+
     def get_actions(self):
         return [{
-            'name': 'generalexample',
+            'name': 'add',
             'icon': 'fa fa-plus',
-            'title': 'general of action',
+            'title': _('Add person'),
             'class': 'btn-outline-success'
         }]

--- a/demo/demoapp/gtstorymap.py
+++ b/demo/demoapp/gtstorymap.py
@@ -93,7 +93,7 @@ class GigaPixelStoryMapExample(BaseStoryMapGPView):
                     "media": {
                         "caption": "Seurat made several studies for the large painting including a smaller version. Study for La Grand Jatte, 1884. ",
                         "credit": "Georges Seurat",
-                        "url": "http://upload.wikimedia.org/wikipedia/commons/thumb/3/3a/Study_for_La_Grande_Jatte%2C_Georges_Seurat%2C_1884.jpg/800px-Study_for_La_Grande_Jatte%2C_Georges_Seurat%2C_1884.jpg"
+                        "url": "https://upload.wikimedia.org/wikipedia/commons/3/3a/Study_for_La_Grande_Jatte%2C_Georges_Seurat%2C_1884.jpg"
                     },
                     "text": {
                         "headline": "Dots as Solid Forms from a Distance",
@@ -169,7 +169,7 @@ class GigaPixelStoryMapExample(BaseStoryMapGPView):
                     "media": {
                         "caption": "Cattle led to sacrifice, South XLV, 137–140, British Museum.",
                         "credit": "Wikipedia",
-                        "url": "http://upload.wikimedia.org/wikipedia/commons/thumb/7/79/Sacrifice_south_frieze_Parthenon_BM.jpg/794px-Sacrifice_south_frieze_Parthenon_BM.jpg"
+                        "url": "https://upload.wikimedia.org/wikipedia/commons/7/79/Sacrifice_south_frieze_Parthenon_BM.jpg"
                     },
                     "text": {
                         "headline": "Procession",

--- a/demo/demoapp/gtstorymap.py
+++ b/demo/demoapp/gtstorymap.py
@@ -93,7 +93,7 @@ class GigaPixelStoryMapExample(BaseStoryMapGPView):
                     "media": {
                         "caption": "Seurat made several studies for the large painting including a smaller version. Study for La Grand Jatte, 1884. ",
                         "credit": "Georges Seurat",
-                        "url": "https://upload.wikimedia.org/wikipedia/commons/3/3a/Study_for_La_Grande_Jatte%2C_Georges_Seurat%2C_1884.jpg"
+                        "url": "//upload.wikimedia.org/wikipedia/commons/3/3a/Study_for_La_Grande_Jatte%2C_Georges_Seurat%2C_1884.jpg"
                     },
                     "text": {
                         "headline": "Dots as Solid Forms from a Distance",
@@ -169,7 +169,7 @@ class GigaPixelStoryMapExample(BaseStoryMapGPView):
                     "media": {
                         "caption": "Cattle led to sacrifice, South XLV, 137–140, British Museum.",
                         "credit": "Wikipedia",
-                        "url": "https://upload.wikimedia.org/wikipedia/commons/7/79/Sacrifice_south_frieze_Parthenon_BM.jpg"
+                        "url": "//upload.wikimedia.org/wikipedia/commons/7/79/Sacrifice_south_frieze_Parthenon_BM.jpg"
                     },
                     "text": {
                         "headline": "Procession",

--- a/demo/demoapp/locale/es/LC_MESSAGES/django.po
+++ b/demo/demoapp/locale/es/LC_MESSAGES/django.po
@@ -1,0 +1,17 @@
+# SOME DESCRIPTIVE TITLE.
+# Copyright (C) YEAR THE PACKAGE'S COPYRIGHT HOLDER
+# This file is distributed under the same license as the PACKAGE package.
+# FIRST AUTHOR <EMAIL@ADDRESS>, YEAR.
+#
+msgid ""
+msgstr ""
+"Project-Id-Version: \n"
+"Report-Msgid-Bugs-To: \n"
+"Language: es\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Plural-Forms: nplurals=2; plural=(n != 1);\n"
+
+msgid "empty"
+msgstr "Vacío"

--- a/demo/demoapp/templates/gentelella/cardlist/cardList.html
+++ b/demo/demoapp/templates/gentelella/cardlist/cardList.html
@@ -12,19 +12,139 @@
 		</div>
 	</div>
 </div>
+
+{% url 'api-personcard-list' as create_person_url %}
+{% trans 'Add person' as create_person_title %}
+{% include 'gentelella/blocks/modal_template.html' with form=create_form id="create_person_modal" title=create_person_title form_id="create_person_form" url=create_person_url %}
+
+{% url 'api-personcard-detail' 0 as update_person_url %}
+{% trans 'Edit person' as update_person_title %}
+{% include 'gentelella/blocks/modal_template.html' with form=update_form id="update_person_modal" title=update_person_title form_id="update_person_form" url=update_person_url %}
+
+{% trans 'Delete person' as delete_person_title %}
+{% include 'gentelella/blocks/modal_template_delete.html' with id="delete_person_modal" title=delete_person_title form_id="delete_person_form" url=update_person_url %}
 {% endblock %}
 
 {% block js %}
 {{block.super}}
 <script>
+	// The detail url carries pk=0 as a placeholder -- personDetailUrl() picks
+	// the real one back out for each request, same convention as
+	// object_management.html's object_urls.
+	//
+	// Reversed fresh here instead of reusing update_person_url from the
+	// content block above: a Django block tag pushes its own context layer,
+	// so a template variable assigned inside one block is gone by the time a
+	// sibling block -- this one -- renders. object_management.html has the
+	// same shape and the same bug (its object_urls.create_url/update_url are
+	// empty for exactly this reason); its list_url dodges it by reversing the
+	// url tag directly instead of reusing a variable, same as here.
+	const personDetailUrlTemplate = "{% url 'api-personcard-detail' 0 %}";
+	function personDetailUrl(pk) {
+		return personDetailUrlTemplate.replace('/0/', '/' + pk + '/');
+	}
+
+	function fillCountrySelect2(selectId, country) {
+		const select = $('#' + selectId);
+		select.empty();
+		if (country) {
+			select.append(new Option(country.name, country.id, true, true));
+		}
+		select.trigger('change');
+	}
+
+	function fillPersonForm(prefix, data) {
+		document.getElementById('id_' + prefix + 'name').value = data.name || '';
+		document.getElementById('id_' + prefix + 'num_children').value = data.num_children;
+		document.getElementById('id_' + prefix + 'born_date').value = data.born_date || '';
+		document.getElementById('id_' + prefix + 'last_time').value = data.last_time || '';
+		fillCountrySelect2('id_' + prefix + 'country', data.country);
+	}
+
+	function showFormErrors(formSelector, prefix, errors) {
+		const form = $(formSelector);
+		form.find('ul.form_errors').remove();
+		form_field_errors(form, errors, prefix, '.gtformfield');
+	}
+
+	function submitPersonForm(url, method, formSelector, prefix, modalEl) {
+		convertToStringJson($(formSelector), prefix).then(function (body) {
+			fetch(url, {
+				method: method,
+				body: body,
+				headers: {
+					'X-CSRFToken': getCookie('csrftoken'),
+					'Content-Type': 'application/json'
+				}
+			}).then(function (response) {
+				if (response.ok) {
+					bootstrap.Modal.getOrCreateInstance(modalEl).hide();
+					cardList.fetchData();
+				} else {
+					response.json().then(function (errors) {
+						showFormErrors(formSelector, prefix, errors);
+					});
+				}
+			});
+		});
+	}
+
+	// Which row the edit/delete modal is currently open for -- the API url
+	// needs the pk and the row click is the only place that has it.
+	let editingPk = null;
+	let deletingPk = null;
+
 	const cardList = new CardList("cardListContainer", "{% url 'api-personcard-list' %}",
 	{
-	'example': function(pk, data, target){
-			console.log(data);
+		'add': function () {
+			const modalEl = document.getElementById('create_person_modal');
+			clear_action_form($('#create_person_form'));
+			bootstrap.Modal.getOrCreateInstance(modalEl).show();
 		},
-	 'generalexample': function(){
-	 				console.log("general example");
-	 }
-	 });
+		'edit': function (pk, data) {
+			editingPk = pk;
+			const modalEl = document.getElementById('update_person_modal');
+			fetch(personDetailUrl(pk))
+				.then(response => response.json())
+				.then(function (values) {
+					fillPersonForm('update-', values);
+					bootstrap.Modal.getOrCreateInstance(modalEl).show();
+				});
+		},
+		'delete': function (pk, data) {
+			deletingPk = pk;
+			const modalEl = document.getElementById('delete_person_modal');
+			modalEl.querySelector('.objtext').textContent = data.name;
+			bootstrap.Modal.getOrCreateInstance(modalEl).show();
+		}
+	});
+
+	document.getElementById('create_person_modal').querySelector('.formadd')
+		.addEventListener('click', function () {
+			submitPersonForm(
+				"{% url 'api-personcard-list' %}", 'POST', '#create_person_form', 'create-',
+				document.getElementById('create_person_modal'));
+		});
+
+	document.getElementById('update_person_modal').querySelector('.formadd')
+		.addEventListener('click', function () {
+			submitPersonForm(
+				personDetailUrl(editingPk), 'PUT', '#update_person_form', 'update-',
+				document.getElementById('update_person_modal'));
+		});
+
+	document.getElementById('delete_person_modal').querySelector('.delbtn')
+		.addEventListener('click', function () {
+			const modalEl = document.getElementById('delete_person_modal');
+			fetch(personDetailUrl(deletingPk), {
+				method: 'DELETE',
+				headers: {'X-CSRFToken': getCookie('csrftoken')}
+			}).then(function (response) {
+				if (response.ok) {
+					bootstrap.Modal.getOrCreateInstance(modalEl).hide();
+					cardList.fetchData();
+				}
+			});
+		});
 </script>
 {% endblock js %}

--- a/demo/demoapp/templates/gentelella/cardlist/cardList.html
+++ b/demo/demoapp/templates/gentelella/cardlist/cardList.html
@@ -28,123 +28,60 @@
 {% block js %}
 {{block.super}}
 <script>
-	// The detail url carries pk=0 as a placeholder -- personDetailUrl() picks
-	// the real one back out for each request, same convention as
-	// object_management.html's object_urls.
-	//
-	// Reversed fresh here instead of reusing update_person_url from the
-	// content block above: a Django block tag pushes its own context layer,
-	// so a template variable assigned inside one block is gone by the time a
-	// sibling block -- this one -- renders. object_management.html has the
-	// same shape and the same bug (its object_urls.create_url/update_url are
-	// empty for exactly this reason); its list_url dodges it by reversing the
-	// url tag directly instead of reusing a variable, same as here.
 	const personDetailUrlTemplate = "{% url 'api-personcard-detail' 0 %}";
 	function personDetailUrl(pk) {
 		return personDetailUrlTemplate.replace('/0/', '/' + pk + '/');
 	}
 
-	function fillCountrySelect2(selectId, country) {
-		const select = $('#' + selectId);
-		select.empty();
-		if (country) {
-			select.append(new Option(country.name, country.id, true, true));
-		}
-		select.trigger('change');
+	function refreshEvents() {
+		return {
+			form_submit: function () { return {}; },
+			error_form: function () {},
+			success_form: function () { cardList.fetchData(); }
+		};
 	}
 
-	function fillPersonForm(prefix, data) {
-		document.getElementById('id_' + prefix + 'name').value = data.name || '';
-		document.getElementById('id_' + prefix + 'num_children').value = data.num_children;
-		document.getElementById('id_' + prefix + 'born_date').value = data.born_date || '';
-		document.getElementById('id_' + prefix + 'last_time').value = data.last_time || '';
-		fillCountrySelect2('id_' + prefix + 'country', data.country);
-	}
+	const createForm = GTBaseFormModal('#create_person_modal', null, {
+		reload_table: false,
+		events: refreshEvents()
+	});
+	createForm.init();
 
-	function showFormErrors(formSelector, prefix, errors) {
-		const form = $(formSelector);
-		form.find('ul.form_errors').remove();
-		form_field_errors(form, errors, prefix, '.gtformfield');
-	}
+	const updateForm = GTBaseFormModal('#update_person_modal', null, {
+		type: 'PUT',
+		reload_table: false,
+		relation_render: {country: 'name'},
+		events: refreshEvents()
+	});
+	updateForm.init();
 
-	function submitPersonForm(url, method, formSelector, prefix, modalEl) {
-		convertToStringJson($(formSelector), prefix).then(function (body) {
-			fetch(url, {
-				method: method,
-				body: body,
-				headers: {
-					'X-CSRFToken': getCookie('csrftoken'),
-					'Content-Type': 'application/json'
-				}
-			}).then(function (response) {
-				if (response.ok) {
-					bootstrap.Modal.getOrCreateInstance(modalEl).hide();
-					cardList.fetchData();
-				} else {
-					response.json().then(function (errors) {
-						showFormErrors(formSelector, prefix, errors);
-					});
-				}
-			});
-		});
-	}
-
-	// Which row the edit/delete modal is currently open for -- the API url
-	// needs the pk and the row click is the only place that has it.
-	let editingPk = null;
-	let deletingPk = null;
+	const deleteForm = GTBaseFormModal('#delete_person_modal', null, {
+		type: 'DELETE',
+		btn_class: '.delbtn',
+		reload_table: false,
+		events: refreshEvents()
+	});
+	deleteForm.init();
 
 	const cardList = new CardList("cardListContainer", "{% url 'api-personcard-list' %}",
 	{
 		'add': function () {
-			const modalEl = document.getElementById('create_person_modal');
-			clear_action_form($('#create_person_form'));
-			bootstrap.Modal.getOrCreateInstance(modalEl).show();
+			createForm.show_modal();
 		},
-		'edit': function (pk, data) {
-			editingPk = pk;
-			const modalEl = document.getElementById('update_person_modal');
+		'edit': function (pk) {
 			fetch(personDetailUrl(pk))
 				.then(response => response.json())
 				.then(function (values) {
-					fillPersonForm('update-', values);
-					bootstrap.Modal.getOrCreateInstance(modalEl).show();
+					updateForm.fill_form(values);
+					updateForm.url = personDetailUrl(pk);
+					updateForm.show_modal();
 				});
 		},
 		'delete': function (pk, data) {
-			deletingPk = pk;
-			const modalEl = document.getElementById('delete_person_modal');
-			modalEl.querySelector('.objtext').textContent = data.name;
-			bootstrap.Modal.getOrCreateInstance(modalEl).show();
+			deleteForm.url = personDetailUrl(pk);
+			deleteForm.instance.find('.objtext').text(data.name);
+			deleteForm.show_modal();
 		}
 	});
-
-	document.getElementById('create_person_modal').querySelector('.formadd')
-		.addEventListener('click', function () {
-			submitPersonForm(
-				"{% url 'api-personcard-list' %}", 'POST', '#create_person_form', 'create-',
-				document.getElementById('create_person_modal'));
-		});
-
-	document.getElementById('update_person_modal').querySelector('.formadd')
-		.addEventListener('click', function () {
-			submitPersonForm(
-				personDetailUrl(editingPk), 'PUT', '#update_person_form', 'update-',
-				document.getElementById('update_person_modal'));
-		});
-
-	document.getElementById('delete_person_modal').querySelector('.delbtn')
-		.addEventListener('click', function () {
-			const modalEl = document.getElementById('delete_person_modal');
-			fetch(personDetailUrl(deletingPk), {
-				method: 'DELETE',
-				headers: {'X-CSRFToken': getCookie('csrftoken')}
-			}).then(function (response) {
-				if (response.ok) {
-					bootstrap.Modal.getOrCreateInstance(modalEl).hide();
-					cardList.fetchData();
-				}
-			});
-		});
 </script>
 {% endblock js %}

--- a/demo/demoapp/templates/gentelella/positionsgrid/warehouse.html
+++ b/demo/demoapp/templates/gentelella/positionsgrid/warehouse.html
@@ -47,6 +47,7 @@
 
 	const grid = new PositionsGrid('warehouseGrid', {
 		editable: true,
+		itemRemoveButton: true,
 		renderItem: function (item) {
 			return '<div class="card card-body p-2">' +
 				   '<strong>' + item.code + '</strong>' +
@@ -54,7 +55,7 @@
 				   ' (' + item.quantity + ')</small></div>';
 		},
 		renderEmptyCell: function () {
-			return '<span class="text-muted small">{% trans "empty" %}</span>';
+			return '<span class="text-muted small d-block text-center fw-bold p-1">{% trans "empty" %}</span>';
 		},
 		handlers: {
 			addRow: function () { return warehousePost('add_row'); },

--- a/djgentelella/firmador_digital/utils.py
+++ b/djgentelella/firmador_digital/utils.py
@@ -163,13 +163,6 @@ class RemoteSignerClient:
     def get_error_response(self, error_msg, details, status, code):
         return {
             'result': False,
-            # str(), not the gettext_lazy proxy _() returns at every call
-            # site: channels' encode_json calls the stdlib json.dumps
-            # directly (no DjangoJSONEncoder), which cannot serialize it --
-            # TypeError: Object of type __proxy__ is not JSON serializable,
-            # thrown from inside send_json, after the real error was already
-            # handled. str() resolves the translation now, in whatever
-            # language is active for this request.
             'error': str(error_msg),
             'details': details,
             'status': status,

--- a/djgentelella/firmador_digital/utils.py
+++ b/djgentelella/firmador_digital/utils.py
@@ -8,6 +8,7 @@ from django.core.files.base import ContentFile
 from django.utils.timezone import now
 from django.utils.translation import gettext_lazy as _
 from requests import HTTPError, Timeout, RequestException
+from requests.exceptions import JSONDecodeError
 
 from djgentelella.firmador_digital.models import UserSignatureConfig
 from djgentelella.models import ChunkedUpload
@@ -44,10 +45,48 @@ class RemoteSignerClient:
             'certToken': self.load_certificate(usertoken),
         }
 
-        response = requests.post(
-            settings.FIRMADOR_SIGN_URL, json=files
-        )
-        return response.json()
+        try:
+            response = requests.post(settings.FIRMADOR_SIGN_URL, json=files)
+            return response.json()
+        except JSONDecodeError as errj:
+            try:
+                data = response.json(strict=False)
+            except JSONDecodeError:
+                logger.error(
+                    'Invalid JSON from signing service: %s -- body: %.500s',
+                    str(errj), response.text, exc_info=errj
+                )
+                return self.get_error_response(
+                    _('The signing service returned an invalid response.'),
+                    response.text[:500], 502, 2
+                )
+            logger.warning(
+                'Signing service answered with a stray control character '
+                '(likely an unescaped stacktrace); recovered its message: %s',
+                data.get('error') or data.get('detail')
+            )
+            message = data.get('error') or data.get('detail') or str(errj)
+            return self.get_error_response(message, message, response.status_code, 0)
+        except ConnectionError as errc:
+            logger.error(
+                'ConnectionError sending document to sign: %s', str(errc), exc_info=errc
+            )
+            error_msg = _('Unable to connect to the signing service.')
+            return self.get_error_response(error_msg, str(errc), 503, 2)
+        except Timeout as errt:
+            logger.error(
+                'Timeout sending document to sign: %s', str(errt), exc_info=errt
+            )
+            error_msg = _('The request to the signing service timed out.')
+            return self.get_error_response(error_msg, str(errt), 408, 12)
+        except RequestException as errr:
+            logger.error(
+                'RequestException sending document to sign: %s', str(errr), exc_info=errr
+            )
+            error_msg = _(
+                'An exception occurred in the request to the signing service.'
+            )
+            return self.get_error_response(error_msg, str(errr), 500, 999)
 
     def validate_document(self, instance):
         b64doc = self.get_b64document(instance['value'])
@@ -124,7 +163,14 @@ class RemoteSignerClient:
     def get_error_response(self, error_msg, details, status, code):
         return {
             'result': False,
-            'error': error_msg,
+            # str(), not the gettext_lazy proxy _() returns at every call
+            # site: channels' encode_json calls the stdlib json.dumps
+            # directly (no DjangoJSONEncoder), which cannot serialize it --
+            # TypeError: Object of type __proxy__ is not JSON serializable,
+            # thrown from inside send_json, after the real error was already
+            # handled. str() resolves the translation now, in whatever
+            # language is active for this request.
+            'error': str(error_msg),
             'details': details,
             'status': status,
             'code': code,

--- a/djgentelella/locale/es/LC_MESSAGES/djangojs.po
+++ b/djgentelella/locale/es/LC_MESSAGES/djangojs.po
@@ -371,3 +371,33 @@ msgstr "CC Direcciones"
 msgid "BCC addresses"
 msgstr "BCC direcciones"
 
+msgid "Positions"
+msgstr "Posiciones"
+
+msgid "Add row"
+msgstr "Agregar fila"
+
+msgid "Remove row %(n)s"
+msgstr "Eliminar fila %(n)s"
+
+msgid "Add column"
+msgstr "Agregar columna"
+
+msgid "Remove column %(n)s"
+msgstr "Eliminar columna %(n)s"
+
+msgid "Add item here"
+msgstr "Agregar elemento aquí"
+
+msgid "Remove item"
+msgstr "Eliminar elemento"
+
+msgid "Row %(row)s, column %(col)s, %(count)s items"
+msgstr "Fila %(row)s, columna %(col)s, %(count)s elementos"
+
+msgid "Item selected. Choose a destination cell."
+msgstr "Elemento seleccionado. Elija una celda de destino."
+
+msgid "Move cancelled."
+msgstr "Movimiento cancelado."
+

--- a/djgentelella/management/commands/loaddevstatic.py
+++ b/djgentelella/management/commands/loaddevstatic.py
@@ -479,8 +479,14 @@ class Command(BaseCommand):
                 # to a canvas through getDocument/getViewport/render. It took
                 # the whole images/ directory with it, which existed only to
                 # feed its url()s.
-                'https://cdnjs.cloudflare.com/ajax/libs/pdf.js/6.2.108/pdf.min.mjs',
-                'https://cdnjs.cloudflare.com/ajax/libs/pdf.js/6.2.108/pdf.worker.min.mjs',
+                # 5.5.207+ (and all of 6.x) call Map.prototype.getOrInsertComputed
+                # natively with no polyfill/fallback -- that's a very recent JS
+                # engine method (TC39 Upsert proposal) most browsers don't ship
+                # yet, and it throws "getOrInsertComputed is not a function" deep
+                # inside rendering. Pinned to the last 5.4.x release that doesn't
+                # use it.
+                'https://cdnjs.cloudflare.com/ajax/libs/pdf.js/5.4.624/pdf.min.mjs',
+                'https://cdnjs.cloudflare.com/ajax/libs/pdf.js/5.4.624/pdf.worker.min.mjs',
             ],
 
             'htmx': [

--- a/djgentelella/static/gentelella/css/positionsgrid.css
+++ b/djgentelella/static/gentelella/css/positionsgrid.css
@@ -27,6 +27,19 @@
 	gap: .5rem;
 	margin-bottom: .5rem;
 	flex-wrap: wrap;
+	justify-content: space-between;
+	align-items: center;
+}
+
+.pg-toolbar-group {
+	display: flex;
+	align-items: center;
+	gap: .5rem;
+}
+
+.pg-toolbar-title {
+	margin: 0;
+	font-size: 1rem;
 }
 
 /* The horizontal scroll lives here and nowhere else. overscroll-behavior stops
@@ -38,6 +51,34 @@
 	overscroll-behavior-x: contain;
 	-webkit-overflow-scrolling: touch;
 	padding-bottom: .25rem;
+
+	/* Without snapping, a wheel or trackpad scroll can stop with a column
+	 * half off the edge -- its remove button half-cut and unclickable,
+	 * looking like the grid overflowed rather than like there is one more
+	 * column to reach. Snapping always settles on a whole column. */
+	scroll-snap-type: x mandatory;
+
+	/* A thin auto-hiding scrollbar at the bottom of the whole grid gives no
+	 * hint that off-screen columns exist while looking at row 1 -- there is
+	 * nothing to see or hover near the top. Always-on and coloured, it reads
+	 * as "there is more, drag me" instead of looking like the far columns
+	 * were simply cut off. */
+	scrollbar-width: thin;
+	scrollbar-color: var(--pg-accent) var(--pg-cell-border);
+}
+
+.pg-scroll::-webkit-scrollbar {
+	height: 10px;
+}
+
+.pg-scroll::-webkit-scrollbar-track {
+	background: var(--pg-cell-border);
+	border-radius: 6px;
+}
+
+.pg-scroll::-webkit-scrollbar-thumb {
+	background: var(--pg-accent);
+	border-radius: 6px;
 }
 
 /* The scroll content: never narrower than the widest row needs, so the
@@ -63,6 +104,7 @@
 .pg-head-cell {
 	display: flex;
 	justify-content: center;
+	scroll-snap-align: start;
 }
 
 .pg-gutter {
@@ -72,6 +114,7 @@
 	justify-content: flex-start;
 	gap: .25rem;
 	color: var(--pg-muted);
+	scroll-snap-align: start;
 }
 
 .pg-rownum {
@@ -88,6 +131,7 @@
 	background: var(--pg-cell-bg);
 	border: 1px solid var(--pg-cell-border);
 	border-radius: var(--bs-border-radius, .375rem);
+	scroll-snap-align: start;
 }
 
 .pg-cell-items {
@@ -97,7 +141,24 @@
 	flex: 1 1 auto;
 }
 
+/* create-item stretches full width by default -- .pg-cell is a column flex
+ * container and stretch is its own default align-items. Centred and a size
+ * down from the 44px touch target reads as "add one more" rather than
+ * competing with the items above it for the whole cell.
+ *
+ * `.pg .pg-cell-add`, not the plain class: `.pg [data-pg-action]` below is
+ * two compound selectors (0,2,0) and a bare class (0,1,0) loses to it on
+ * specificity no matter which rule comes later in the file -- see the same
+ * note on .pg-item-remove. */
+.pg .pg-cell-add {
+	align-self: center;
+	min-width: 32px;
+	min-height: 32px;
+	font-size: .8rem;
+}
+
 .pg-item {
+	position: relative;
 	min-height: var(--pg-touch);
 	cursor: pointer;
 	border-radius: var(--bs-border-radius-sm, .25rem);
@@ -116,6 +177,44 @@
 	display: inline-flex;
 	align-items: center;
 	justify-content: center;
+}
+
+/* Remove row/column stand right next to the row numbers and column heads,
+ * both small chrome of their own -- at 44x44 they read as the loudest thing
+ * in the gutter/head row instead of a secondary action. Still a real click
+ * target, just not a WCAG-sized touch one: a deliberate exception, same
+ * trade-off as remove-item below. create-item is the one that stays full
+ * size -- it is the primary action of an empty cell, not a secondary one. */
+.pg-gutter [data-pg-action],
+.pg-head-cell [data-pg-action] {
+	min-width: 28px;
+	min-height: 28px;
+	font-size: .75rem;
+}
+
+/* Sits in the corner of the item it removes, so it never touches renderItem's
+ * own layout underneath. Smaller than a touch target on purpose -- see the
+ * comment on the gutter/head remove buttons above, same trade-off.
+ *
+ * Selector is `.pg .pg-item-remove`, not the plain class: `.pg [data-pg-action]`
+ * above is two compound selectors (0,2,0) and a bare `.pg-item-remove` (0,1,0)
+ * loses to it on specificity regardless of which rule comes later in the
+ * file -- the 44px touch-target min-width/height wins and the button renders
+ * full size no matter what this rule says. Matching that specificity here is
+ * what makes the override actually take. */
+.pg .pg-item-remove {
+	position: absolute;
+	top: 2px;
+	right: 2px;
+	min-width: 16px;
+	min-height: 16px;
+	padding: 0;
+	font-size: .6rem;
+	line-height: 1;
+	background: var(--pg-cell-bg);
+	border: 1px solid var(--pg-cell-border);
+	border-radius: var(--bs-border-radius-sm, .25rem);
+	color: var(--bs-danger, #dc3545);
 }
 
 .pg-cell:focus-visible,

--- a/djgentelella/static/gentelella/css/positionsgrid.css
+++ b/djgentelella/static/gentelella/css/positionsgrid.css
@@ -24,17 +24,17 @@
 
 .pg-toolbar {
 	display: flex;
-	gap: .5rem;
+	gap: 1.5rem;
 	margin-bottom: .5rem;
 	flex-wrap: wrap;
-	justify-content: space-between;
-	align-items: center;
+	align-items: flex-start;
 }
 
 .pg-toolbar-group {
 	display: flex;
+	flex-direction: column;
 	align-items: center;
-	gap: .5rem;
+	gap: .25rem;
 }
 
 .pg-toolbar-title {
@@ -141,21 +141,8 @@
 	flex: 1 1 auto;
 }
 
-/* create-item stretches full width by default -- .pg-cell is a column flex
- * container and stretch is its own default align-items. Centred and a size
- * down from the 44px touch target reads as "add one more" rather than
- * competing with the items above it for the whole cell.
- *
- * `.pg .pg-cell-add`, not the plain class: `.pg [data-pg-action]` below is
- * two compound selectors (0,2,0) and a bare class (0,1,0) loses to it on
- * specificity no matter which rule comes later in the file -- see the same
- * note on .pg-item-remove. */
-.pg .pg-cell-add {
-	align-self: center;
-	min-width: 32px;
-	min-height: 32px;
-	font-size: .8rem;
-}
+/* create-item is full width on purpose -- no override needed: .pg-cell is a
+ * column flex container and stretch is its own default align-items. */
 
 .pg-item {
 	position: relative;
@@ -192,6 +179,16 @@
 	font-size: .75rem;
 }
 
+/* Just the icon: no btn-outline-danger border/background, which read as
+ * heavier chrome than this secondary action calls for next to the plain row
+ * number/column head it sits beside. */
+.pg-icon-remove {
+	background: none;
+	border: none;
+	padding: 0;
+	color: var(--bs-danger, #dc3545);
+}
+
 /* Sits in the corner of the item it removes, so it never touches renderItem's
  * own layout underneath. Smaller than a touch target on purpose -- see the
  * comment on the gutter/head remove buttons above, same trade-off.
@@ -204,8 +201,16 @@
  * what makes the override actually take. */
 .pg .pg-item-remove {
 	position: absolute;
-	top: 2px;
-	right: 2px;
+	/* The theme's global `button { margin-right: 5px; margin-bottom: 5px }`
+	 * (custom.css) applies to every plain <button>, this one included, and
+	 * this rule never reset it -- an absolutely positioned box's margin still
+	 * counts on the side across from the offset it did not set (`left` was
+	 * auto here), so `right: 2px` rendered as 2px + that 5px margin, 7px in
+	 * total, while `top` -- set directly, with `bottom` auto -- was never
+	 * affected. That mismatch, not the 2px/2px values, was the uneven gap. */
+	margin: 0;
+	top: 4px;
+	right: 4px;
 	min-width: 16px;
 	min-height: 16px;
 	padding: 0;

--- a/djgentelella/static/gentelella/js/base/chunkedupload.js
+++ b/djgentelella/static/gentelella/js/base/chunkedupload.js
@@ -92,8 +92,11 @@ function gt_chunked_upload(options) {
         var form = new FormData();
         form.append('csrfmiddlewaretoken', options.csrf);
         // The filename has to travel with the slice: the view takes the name
-        // of the upload from the first chunk it receives.
-        form.append('file', file.slice(start, end), file.name);
+        // of the upload from the first chunk it receives. Blob.slice() drops
+        // the original type unless it is passed back in explicitly -- without
+        // it every chunk's Content-Type becomes application/octet-stream, and
+        // the server-side type check rejects the file no matter what it is.
+        form.append('file', file.slice(start, end, file.type), file.name);
         if (upload_id) {
             form.append('upload_id', upload_id);
         }

--- a/djgentelella/static/gentelella/js/base/digital_signature.js
+++ b/djgentelella/static/gentelella/js/base/digital_signature.js
@@ -754,7 +754,8 @@ function FirmadorLibreWS(docmanager, url, signatureManager) {
                     if (data.details.includes("Connection refused")) {
                         signatureManager.addError(3);
                     } else {
-                        alertSimple(errorInterpreter(999), gettext("Error"), "error");
+                        // is only a fallback for when there is no message.
+                        alertSimple(data.error || errorInterpreter(999), gettext("Error"), "error");
                     }
 
                 } else if (data.code) {

--- a/djgentelella/static/gentelella/js/base/positionsgrid.js
+++ b/djgentelella/static/gentelella/js/base/positionsgrid.js
@@ -34,6 +34,13 @@ var PG_DEFAULTS = {
     drag: null,              // null = auto: only where there is a fine pointer
     handlers: {},            // addRow removeRow addCol removeCol
                              // createItem moveItem removeItem
+    // removeItem (Delete/Backspace on a selected item, see _handleKeydown)
+    // works off the handler alone and needs no opt-in. The button is a
+    // second, separate way to reach the same action and defaults to off:
+    // a permanent little "x" on every item is a bigger visual and layout
+    // commitment than a handler being wired, so a host opts into showing it
+    // on purpose instead of getting it for free.
+    itemRemoveButton: false,
     labels: {}
 };
 
@@ -187,9 +194,9 @@ class PositionsGrid {
         for (var c = 0; c < cols; c++) {
             cells += '<div class="pg-head-cell">' +
                 (this._colIsEmpty(c)
-                    ? this._btn('remove-col', {col: c}, 'fa fa-remove',
+                    ? this._btn('remove-col', {col: c}, 'fa fa-minus',
                                 pg_format(this.cfg.labels.removeCol, {n: c + 1}),
-                                'btn btn-sm btn-outline-danger')
+                                'pg-icon-remove')
                     : '') +
                 '</div>';
         }
@@ -203,9 +210,9 @@ class PositionsGrid {
         return '<div class="pg-row" role="row" aria-rowindex="' + (r + 2) + '">' +
             '<div class="pg-gutter" role="rowheader">' +
                 '<span class="pg-rownum">' + (r + 1) + '</span>' +
-                (canRemove ? this._btn('remove-row', {row: r}, 'fa fa-remove',
+                (canRemove ? this._btn('remove-row', {row: r}, 'fa fa-minus',
                      pg_format(this.cfg.labels.removeRow, {n: r + 1}),
-                     'btn btn-sm btn-outline-danger') : '') +
+                     'pg-icon-remove') : '') +
             '</div>' +
             cells.map(function (ids, c) {
                 return this._renderCell(r, c, ids);
@@ -221,7 +228,7 @@ class PositionsGrid {
             : (this.cfg.renderEmptyCell ? this.cfg.renderEmptyCell(r, c) : '');
         var add = (this.editable && this.handlers.createItem)
             ? this._btn('create-item', {row: r, col: c}, 'fa fa-plus',
-                        this.cfg.labels.createItem, 'btn btn-sm btn-success pg-cell-add')
+                        this.cfg.labels.createItem, 'btn btn-sm btn-secondary pg-cell-add')
             : '';
         return '<div class="pg-cell" role="gridcell" tabindex="-1"' +
                ' data-pg-row="' + r + '" data-pg-col="' + c + '"' +
@@ -248,7 +255,7 @@ class PositionsGrid {
         // on top of. Delete/Backspace already removes the selected item (see
         // _handleKeydown); this is the same action made visible and clickable
         // instead of only reachable once you know the shortcut exists.
-        var remove = (this.editable && this.handlers.removeItem)
+        var remove = (this.editable && this.handlers.removeItem && this.cfg.itemRemoveButton)
             ? this._btn('remove-item', {item: id}, 'fa fa-remove',
                         this.cfg.labels.removeItem, 'pg-item-remove')
             : '';

--- a/djgentelella/static/gentelella/js/base/positionsgrid.js
+++ b/djgentelella/static/gentelella/js/base/positionsgrid.js
@@ -66,6 +66,7 @@ class PositionsGrid {
             addCol: pg_gettext('Add column'),
             removeCol: pg_gettext('Remove column %(n)s'),
             createItem: pg_gettext('Add item here'),
+            removeItem: pg_gettext('Remove item'),
             cell: pg_gettext('Row %(row)s, column %(col)s, %(count)s items'),
             picked: pg_gettext('Item selected. Choose a destination cell.'),
             cancelled: pg_gettext('Move cancelled.')
@@ -150,29 +151,46 @@ class PositionsGrid {
     }
 
     _renderToolbar() {
-        var out = '';
+        var start = '';
+        var end = '';
         if (this.editable && this.handlers.addRow) {
-            out += this._btn('add-row', {}, 'fa fa-plus', this.cfg.labels.addRow,
-                             'btn btn-sm btn-outline-primary');
+            start = '<div class="pg-toolbar-group pg-toolbar-start">' +
+                '<h5 class="pg-toolbar-title">' + pg_escape(this.cfg.labels.addRow) + '</h5>' +
+                this._btn('add-row', {}, 'fa fa-plus', this.cfg.labels.addRow,
+                          'btn btn-sm btn-outline-primary') +
+                '</div>';
         }
         if (this.editable && this.handlers.addCol) {
-            out += this._btn('add-col', {}, 'fa fa-plus', this.cfg.labels.addCol,
-                             'btn btn-sm btn-outline-primary');
+            end = '<div class="pg-toolbar-group pg-toolbar-end">' +
+                '<h5 class="pg-toolbar-title">' + pg_escape(this.cfg.labels.addCol) + '</h5>' +
+                this._btn('add-col', {}, 'fa fa-plus', this.cfg.labels.addCol,
+                          'btn btn-sm btn-outline-primary') +
+                '</div>';
         }
-        return out;
+        return start + end;
     }
 
     // The header row exists only to hold the per-column remove buttons, so it
     // is not rendered at all when the host gave no removeCol handler. Same rule
     // everywhere: a missing handler means the control does not exist, which is
     // how partial permissions compose without a flag per action.
+    // A column/row the server would refuse anyway (it still has boxes) gets
+    // no remove button at all, rather than one that is always a dead end.
+    _colIsEmpty(c) {
+        var rows = (this.data && this.data.cells) || [];
+        return rows.every(function (row) { return !row[c] || !row[c].length; });
+    }
+
     _renderHead(cols) {
         if (!this.editable || !this.handlers.removeCol || !cols) { return ''; }
         var cells = '';
         for (var c = 0; c < cols; c++) {
             cells += '<div class="pg-head-cell">' +
-                this._btn('remove-col', {col: c}, 'fa fa-minus',
-                          pg_format(this.cfg.labels.removeCol, {n: c + 1})) +
+                (this._colIsEmpty(c)
+                    ? this._btn('remove-col', {col: c}, 'fa fa-remove',
+                                pg_format(this.cfg.labels.removeCol, {n: c + 1}),
+                                'btn btn-sm btn-outline-danger')
+                    : '') +
                 '</div>';
         }
         return '<div class="pg-row pg-head" role="row" aria-hidden="true">' +
@@ -180,12 +198,14 @@ class PositionsGrid {
     }
 
     _renderRow(cells, r) {
-        var canRemove = this.editable && this.handlers.removeRow;
+        var canRemove = this.editable && this.handlers.removeRow &&
+            cells.every(function (ids) { return !ids.length; });
         return '<div class="pg-row" role="row" aria-rowindex="' + (r + 2) + '">' +
             '<div class="pg-gutter" role="rowheader">' +
                 '<span class="pg-rownum">' + (r + 1) + '</span>' +
-                (canRemove ? this._btn('remove-row', {row: r}, 'fa fa-minus',
-                     pg_format(this.cfg.labels.removeRow, {n: r + 1})) : '') +
+                (canRemove ? this._btn('remove-row', {row: r}, 'fa fa-remove',
+                     pg_format(this.cfg.labels.removeRow, {n: r + 1}),
+                     'btn btn-sm btn-outline-danger') : '') +
             '</div>' +
             cells.map(function (ids, c) {
                 return this._renderCell(r, c, ids);
@@ -201,7 +221,7 @@ class PositionsGrid {
             : (this.cfg.renderEmptyCell ? this.cfg.renderEmptyCell(r, c) : '');
         var add = (this.editable && this.handlers.createItem)
             ? this._btn('create-item', {row: r, col: c}, 'fa fa-plus',
-                        this.cfg.labels.createItem, 'pg-cell-add')
+                        this.cfg.labels.createItem, 'btn btn-sm btn-success pg-cell-add')
             : '';
         return '<div class="pg-cell" role="gridcell" tabindex="-1"' +
                ' data-pg-row="' + r + '" data-pg-col="' + c + '"' +
@@ -223,9 +243,18 @@ class PositionsGrid {
             ? this.cfg.renderItem(item, id)
             : '<span class="pg-item-default">' +
               pg_escape(item.label !== undefined ? item.label : id) + '</span>';
+        // [data-pg-action] is matched before .pg-item in _handleClick, so this
+        // button's click never falls through to select/move the item it sits
+        // on top of. Delete/Backspace already removes the selected item (see
+        // _handleKeydown); this is the same action made visible and clickable
+        // instead of only reachable once you know the shortcut exists.
+        var remove = (this.editable && this.handlers.removeItem)
+            ? this._btn('remove-item', {item: id}, 'fa fa-remove',
+                        this.cfg.labels.removeItem, 'pg-item-remove')
+            : '';
         return '<div class="pg-item" role="button" tabindex="-1" aria-pressed="false"' +
                (draggable ? ' draggable="true"' : '') +
-               ' data-pg-item="' + pg_escape(id) + '">' + body + '</div>';
+               ' data-pg-item="' + pg_escape(id) + '">' + body + remove + '</div>';
     }
 
     _btn(action, args, icon, label, cls) {
@@ -409,6 +438,12 @@ class PositionsGrid {
         if (action === 'create-item') {
             return this.createItem(parseInt(btn.dataset.pgRow, 10),
                                    parseInt(btn.dataset.pgCol, 10));
+        }
+        if (action === 'remove-item') {
+            // Ids are opaque and may not be numbers -- this._ids maps the
+            // stringified data attribute back to what the server sent,
+            // same as the Delete/Backspace path in _handleKeydown.
+            return this.removeItem(this._ids[btn.dataset.pgItem]);
         }
     }
 

--- a/djgentelella/static/gentelella/js/custom.js
+++ b/djgentelella/static/gentelella/js/custom.js
@@ -610,7 +610,14 @@ function init_validator() {
 };
 
 function init_input_text() {
-    $('input[maxlength]').maxlength();
+    // MapPointInput writes its value from a map click and dispatches a
+    // synthetic 'input' event without ever focusing the field (mappoint.js's
+    // notify()). bootstrap-maxlength only builds its counter badge on focus,
+    // so its own 'input' handler throws reading .outerWidth() on that badge
+    // when it has never been created -- same plugin, same "never focused"
+    // cause the comment on MapPointInput's own input handler already
+    // documents, just reached through this blanket selector instead.
+    $('input[maxlength]').not('[data-widget="MapPointInput"]').maxlength();
 };
 
 

--- a/djgentelella/templates/gentelella/statics/javascript.html
+++ b/djgentelella/templates/gentelella/statics/javascript.html
@@ -54,6 +54,7 @@
 	{% if moment_locale %}
 		<script src="{{ moment_locale }}?v={% get_version %}"></script>
 	{% endif %}
+	<script src="{% static 'vendors/inputmask/inputmask.min.js' %}?v={% get_version %}"></script>
 	<script src="{% static 'vendors/inputmask/jquery.inputmask.min.js' %}?v={% get_version %}"></script>
 	<script src="{% static 'vendors/nprogress/nprogress.min.js' %}?v={% get_version %}"></script>
 	<script src="{% static 'vendors/interact/interact.min.js' %}?v={% get_version %}"></script>

--- a/pylpfile.py
+++ b/pylpfile.py
@@ -110,6 +110,7 @@ JS_FILES_HEADER = [str(BASE_PATH / path) for path in [
 JS_FILES = [str(BASE_PATH / path) for path in [
     'vendors/squirrelly/squirrelly.min.js',
     'vendors/moment/moment.min.js',
+    'vendors/inputmask/inputmask.min.js',
     'vendors/inputmask/jquery.inputmask.min.js',
     'vendors/nprogress/nprogress.min.js',
     'vendors/interact/interact.min.js',


### PR DESCRIPTION
Fixes several bugs found testing the demo: broken knob widget init (missing inputmask.min.js), a wrong radio choice, dead Wikimedia thumbnail URLs in the storymap, chunked PDF uploads losing their MIME type, a crash in MapPointInput from bootstrap-maxlength, positions-grid UX cleanup (smaller/clearer remove buttons, scroll-snap, per-item delete), a stubbed-out CardList demo now with real add/edit/delete, and the digital-signature flow crashing (and showing a useless generic message) when Firmador answers with malformed JSON.